### PR TITLE
Finish building out SerializeCodeSystemToFhir

### DIFF
--- a/internal/app/fhir/r5/CodeSystem.go
+++ b/internal/app/fhir/r5/CodeSystem.go
@@ -3,27 +3,26 @@ package r5
 import (
 	"fmt"
 
+	"github.com/CDCgov/phinvads-go/internal/database/models/xo"
 	"github.com/google/fhir/go/proto/google/fhir/proto/r5/core/codes_go_proto"
 	datatypespb "github.com/google/fhir/go/proto/google/fhir/proto/r5/core/datatypes_go_proto"
 	r5pb "github.com/google/fhir/go/proto/google/fhir/proto/r5/core/resources/code_system_go_proto"
-	"github.com/CDCgov/phinvads-go/internal/database/models/xo"
 )
 
-func SerializeCodeSystemToFhir(cs *xo.CodeSystem) (*r5pb.CodeSystem, error) {
+func SerializeCodeSystemToFhir(cs *xo.CodeSystem, conceptCount int, concepts []*xo.CodeSystemConcept) (*r5pb.CodeSystem, error) {
 	fhirCS := &r5pb.CodeSystem{
 		Id:           newId(cs.Oid),
-		Status:       &r5pb.CodeSystem_StatusCode{Value: codes_go_proto.PublicationStatusCode_DRAFT},
+		Status:       &r5pb.CodeSystem_StatusCode{Value: codes_go_proto.PublicationStatusCode_ACTIVE},
 		Version:      newString(cs.Version),
-		Name:         newString(cs.Name),
+		Name:         newString(cs.Codesystemcode),
 		Description:  newNullableMarkdown(cs.Definitiontext),
 		Experimental: newBoolean(cs.Legacyflag),
-		Url:          newNullableUri(cs.Sourceurl),
+		Url:          newUri(fmt.Sprintf("https://phinvads.cdc.gov/r5/CodeSystem/%s", cs.Oid)),
 		Date:         newDateTime(cs.Statusdate),
 		Publisher:    newNullableString(cs.Distributionsourceversionname),
-		Title:        newNullableString(cs.Assigningauthorityversionname),
+		Title:        newString(cs.Name),
 		Content:      &r5pb.CodeSystem_ContentCode{Value: 4},
-		// TODO: Count
-		// TODO: Concept
+		Count:        newUnsignedInt(conceptCount),
 	}
 
 	fhirCS.Identifier = []*datatypespb.Identifier{
@@ -39,9 +38,16 @@ func SerializeCodeSystemToFhir(cs *xo.CodeSystem) (*r5pb.CodeSystem, error) {
 		},
 	}
 
+	var definitionText string
+	if cs.Definitiontext.Valid {
+		definitionText = cs.Definitiontext.String
+	} else {
+		definitionText = ""
+	}
+
 	fhirCS.Text = &datatypespb.Narrative{
 		Status: &datatypespb.Narrative_StatusCode{Value: codes_go_proto.NarrativeStatusCode_GENERATED},
-		Div:    newXhtml("<div>Your narrative text here</div>"),
+		Div:    newXhtml(fmt.Sprintf("<div xmlns=\"http://www.w3.org/1999/xhtml\">%s</div>", definitionText)),
 	}
 
 	fhirCS.Contact = []*datatypespb.ContactDetail{
@@ -59,6 +65,16 @@ func SerializeCodeSystemToFhir(cs *xo.CodeSystem) (*r5pb.CodeSystem, error) {
 			},
 		},
 	}
+
+	conceptDefinitions := make([]*r5pb.CodeSystem_ConceptDefinition, 0, conceptCount)
+	for _, concept := range concepts {
+		conceptDefinition := &r5pb.CodeSystem_ConceptDefinition{
+			Code:    &datatypespb.Code{Value: concept.Conceptcode},
+			Display: newString(concept.Name),
+		}
+		conceptDefinitions = append(conceptDefinitions, conceptDefinition)
+	}
+	fhirCS.Concept = conceptDefinitions
 
 	return fhirCS, nil
 }

--- a/internal/app/fhir/r5/CodeSystem.go
+++ b/internal/app/fhir/r5/CodeSystem.go
@@ -21,7 +21,7 @@ func SerializeCodeSystemToFhir(cs *xo.CodeSystem, conceptCount int, concepts []*
 		Date:         newDateTime(cs.Statusdate),
 		Publisher:    newNullableString(cs.Distributionsourceversionname),
 		Title:        newString(cs.Name),
-		Content:      &r5pb.CodeSystem_ContentCode{Value: 4},
+		Content:      &r5pb.CodeSystem_ContentCode{Value: codes_go_proto.CodeSystemContentModeCode_COMPLETE},
 		Count:        newUnsignedInt(conceptCount),
 	}
 
@@ -38,11 +38,9 @@ func SerializeCodeSystemToFhir(cs *xo.CodeSystem, conceptCount int, concepts []*
 		},
 	}
 
-	var definitionText string
+	definitionText := ""
 	if cs.Definitiontext.Valid {
 		definitionText = cs.Definitiontext.String
-	} else {
-		definitionText = ""
 	}
 
 	fhirCS.Text = &datatypespb.Narrative{

--- a/internal/app/fhir/r5/CodeSystem.go
+++ b/internal/app/fhir/r5/CodeSystem.go
@@ -53,11 +53,11 @@ func SerializeCodeSystemToFhir(cs *xo.CodeSystem, conceptCount int, concepts []*
 			Name: newString("PHIN Vocabulary Services"),
 			Telecom: []*datatypespb.ContactPoint{
 				{
-					System: &datatypespb.ContactPoint_SystemCode{Value: 5},
+					System: &datatypespb.ContactPoint_SystemCode{Value: codes_go_proto.ContactPointSystemCode_URL},
 					Value:  newString("https://www.cdc.gov/phin/php/phinvads/index.html"),
 				},
 				{
-					System: &datatypespb.ContactPoint_SystemCode{Value: 3},
+					System: &datatypespb.ContactPoint_SystemCode{Value: codes_go_proto.ContactPointSystemCode_EMAIL},
 					Value:  newString("phinvs@cdc.gov"),
 				},
 			},

--- a/internal/app/fhir/r5/helpers.go
+++ b/internal/app/fhir/r5/helpers.go
@@ -64,3 +64,7 @@ func newNullableUri(ns sql.NullString) *datatypespb.Uri {
 func newXhtml(value string) *datatypespb.Xhtml {
 	return &datatypespb.Xhtml{Value: value}
 }
+
+func newUnsignedInt(value int) *datatypespb.UnsignedInt {
+	return &datatypespb.UnsignedInt{Value: uint32(value)}
+}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/fhir/go/fhirversion"
-	"github.com/google/fhir/go/jsonformat"
 	"github.com/CDCgov/phinvads-go/internal/app/fhir/r5"
 	"github.com/CDCgov/phinvads-go/internal/database/models"
 	"github.com/CDCgov/phinvads-go/internal/database/models/xo"
 	customErrors "github.com/CDCgov/phinvads-go/internal/errors"
 	"github.com/CDCgov/phinvads-go/internal/ui/components"
+	"github.com/google/fhir/go/fhirversion"
+	"github.com/google/fhir/go/jsonformat"
 )
 
 func (app *Application) healthcheck(w http.ResponseWriter, r *http.Request) {
@@ -109,21 +109,32 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-
-	fhirCodeSystem, err := r5.SerializeCodeSystemToFhir(codeSystem)
+	conceptCount, err := models.GetCodeSystemConceptCount(r.Context(), app.db, codeSystem.Oid)
 	if err != nil {
 		customErrors.ServerError(w, r, err, app.logger)
+		return
+	}
+
+	concepts, err := rp.GetCodeSystemConceptsByCodeSystemOID(r.Context(), app.db, codeSystem)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	fhirCodeSystem, err := r5.SerializeCodeSystemToFhir(codeSystem, conceptCount, concepts)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+		return
 	}
 
 	marshaller, err := jsonformat.NewMarshaller(false, "", "", fhirversion.R4)
 	if err != nil {
 		customErrors.ServerError(w, r, err, app.logger)
+		return
 	}
 
 	fhirJson, err := marshaller.MarshalResource(fhirCodeSystem)
 	if err != nil {
 		customErrors.ServerError(w, r, err, app.logger)
+		return
 	}
 
 	w.Write(fhirJson)

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -55,3 +55,15 @@ type CodeSystemResultRow struct {
 	URL                     string
 	PageCount               int
 }
+
+func GetCodeSystemConceptCount(ctx context.Context, db xo.DB, oid string) (int, error) {
+	const sqlstr = `SELECT COUNT(*) FROM public.code_system_concept WHERE codesystemoid = $1`
+
+	var count int
+	err := db.QueryRowContext(ctx, sqlstr, oid).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}


### PR DESCRIPTION
This extends the serializer to match the capability of the existing FHIR API, including the addition of concept counts, the concepts themselves, and a few other small changes, like swapping `Name` and `Title` and changing the `Status` to "active".