### PR TITLE
docs: add step to setup `.env` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ git clone https://github.com/CDCgov/phinvads-go.git
 cd phinvads-go
 ```
 
+Create a `.env` file:
+
+```bash
+cp .env.sample .env
+```
+
 ### direnv setup and configuration
 
 1. [Install direnv (`brew install direnv`)](https://direnv.net/docs/installation.html)


### PR DESCRIPTION
`direnv` complained about the lack of a `.env` file, so adding an instruction to copy over the `.env.sample` to `.env` in the dev setup - is anything more needed here?