### PR TITLE
Start adding ValueSet lookup to search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ git clone https://github.com/CDCgov/phinvads-go.git
 cd phinvads-go
 ```
 
+Create a `.env` file:
+
+```bash
+cp .env.sample .env
+```
+
 ### direnv setup and configuration
 
 1. [Install direnv (`brew install direnv`)](https://direnv.net/docs/installation.html)

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -531,31 +531,56 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 	rp := app.repository
 	logger := app.logger
 
-	result := &models.CodeSystemResultRow{}
+	result := &models.SearchResultRow{}
 	defaultPageCount := 5
 
 	lookupType, err := determineParamType(searchTerm)
 
-	var codeSystems *[]xo.CodeSystem
-	codeSystems, err = rp.SearchCodeSystems(r.Context(), searchTerm, lookupType)
-
-	// retrieve code system
-	if err != nil || len(*codeSystems) < 1 {
-		if err == nil {
-			err = sql.ErrNoRows
+	if searchType == "value_set" || searchType == "all" {
+		var valueSets *[]xo.ValueSet
+		valueSets, err = rp.SearchValueSets(r.Context(), searchTerm, lookupType)
+		fmt.Println(len(*valueSets))
+		if err != nil || len(*valueSets) < 1 {
+			if err == nil {
+				err = sql.ErrNoRows
+			}
+			customErrors.SearchError(w, r, err, searchTerm, searchType, logger)
+			return
 		}
-		customErrors.SearchError(w, r, err, searchTerm, logger)
-		return
-	}
+		for _, vs := range *valueSets {
+			result.ValueSets = append(result.ValueSets, &vs)
+		}
 
-	for _, cs := range *codeSystems {
-		result.CodeSystems = append(result.CodeSystems, &cs)
-	}
+		if len(result.ValueSets) <= defaultPageCount {
+			defaultPageCount = len(result.ValueSets)
+		}
 
-	if len(result.CodeSystems) <= defaultPageCount {
-		defaultPageCount = len(result.CodeSystems)
-	}
+		result.PageCount = defaultPageCount
+		result.ValueSetsCount = strconv.Itoa(len(result.ValueSets))
+	} else if searchType == "code_system" {
+		var codeSystems *[]xo.CodeSystem
+		codeSystems, err = rp.SearchCodeSystems(r.Context(), searchTerm, lookupType)
 
+		// retrieve code system
+		if err != nil || len(*codeSystems) < 1 {
+			if err == nil {
+				err = sql.ErrNoRows
+			}
+			customErrors.SearchError(w, r, err, searchTerm, searchType, logger)
+			return
+		}
+
+		for _, cs := range *codeSystems {
+			result.CodeSystems = append(result.CodeSystems, &cs)
+		}
+
+		if len(result.CodeSystems) <= defaultPageCount {
+			defaultPageCount = len(result.CodeSystems)
+		}
+	} else {
+		err = errors.New("Under Construction...")
+		customErrors.SearchError(w, r, err, searchTerm, searchType, logger)
+	}
 	result.PageCount = defaultPageCount
 	result.CodeSystemsCount = strconv.Itoa(len(result.CodeSystems))
 
@@ -570,7 +595,9 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 	result.CodeSystemConceptsCount = strconv.Itoa(0)
 
 	// for now
-	result.ValueSetsCount = strconv.Itoa(0)
+	if result.ValueSetsCount == "" {
+		result.ValueSetsCount = strconv.Itoa(0)
+	}
 
 	w.Header().Set("HX-Push-Url", fmt.Sprintf("/search?type=%s&input=%s", searchType, searchTerm))
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -534,10 +534,9 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 	result := &models.CodeSystemResultRow{}
 	defaultPageCount := 5
 
-	lookupType, _ := determineParamType(searchTerm)
+	lookupType, err := determineParamType(searchTerm)
 
 	var codeSystems *[]xo.CodeSystem
-	var err error
 	codeSystems, err = rp.SearchCodeSystems(r.Context(), searchTerm, lookupType)
 
 	// retrieve code system

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -6,14 +6,17 @@ import (
 	"github.com/CDCgov/phinvads-go/internal/errors"
 )
 
-func determineIdType(input string) (output string, err error) {
-	validId, _ := regexp.MatchString("^[a-zA-Z0-9-]+$", input)
+func determineParamType(input string) (output string, err error) {
+	validId, _ := regexp.MatchString("^[a-zA-Z]+[0-9-]+$", input)
 	validOid, _ := regexp.MatchString("^[0-9.]+$", input)
+	validString, _ := regexp.MatchString("^[a-zA-Z0-9 ]*$", input)
 
 	if validId {
 		return "id", nil
 	} else if validOid {
 		return "oid", nil
+	} else if validString {
+		return "string", nil
 	} else {
 		return "", errors.ErrInvalidId
 	}

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -7,12 +7,12 @@ import (
 )
 
 func determineParamType(input string) (output string, err error) {
-	validId, _ := regexp.MatchString("^[a-zA-Z]+[0-9-]+$", input)
+	validUuid, _ := regexp.MatchString("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", input)
 	validOid, _ := regexp.MatchString("^[0-9.]+$", input)
 	validString, _ := regexp.MatchString("^[a-zA-Z0-9 ]*$", input)
 
-	if validId {
-		return "id", nil
+	if validUuid {
+		return "uuid", nil
 	} else if validOid {
 		return "oid", nil
 	} else if validString {

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -26,9 +26,27 @@ func GetAllCodeSystems(ctx context.Context, db xo.DB) (*[]xo.CodeSystem, error) 
 }
 
 func GetCodeSystemByLikeOID(ctx context.Context, db xo.DB, oid string) (*[]xo.CodeSystem, error) {
-	wildcard := oid + "%"
+	wildcard := "%" + oid + "%"
 	const sqlstr = "SELECT * FROM public.code_system WHERE oid LIKE $1"
 
+	return queryCodeSystems(ctx, db, sqlstr, wildcard)
+}
+
+func GetCodeSystemByLikeID(ctx context.Context, db xo.DB, id string) (*[]xo.CodeSystem, error) {
+	wildcard := "%" + id + "%"
+	const sqlstr = "SELECT * FROM public.code_system WHERE id LIKE $1"
+
+	return queryCodeSystems(ctx, db, sqlstr, wildcard)
+}
+
+func GetCodeSystemByLikeString(ctx context.Context, db xo.DB, input string) (*[]xo.CodeSystem, error) {
+	wildcard := "%" + input + "%"
+	const sqlstr = "SELECT * FROM public.code_system WHERE lower(name) LIKE lower($1) OR lower(codesystemcode) LIKE lower ($1)"
+
+	return queryCodeSystems(ctx, db, sqlstr, wildcard)
+}
+
+func queryCodeSystems(ctx context.Context, db xo.DB, sqlstr, wildcard string) (*[]xo.CodeSystem, error) {
 	codeSystems := []xo.CodeSystem{}
 	rows, err := db.QueryContext(ctx, sqlstr, wildcard)
 	if err != nil {

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -63,13 +63,15 @@ func queryCodeSystems(ctx context.Context, db xo.DB, sqlstr, wildcard string) (*
 	return &codeSystems, nil
 }
 
-type CodeSystemResultRow struct {
+type SearchResultRow struct {
 	CodeSystemsCount        string
 	CodeSystemConceptsCount string
 	ValueSetsCount          string
+	ValueSetConceptsCount   string
 	CodeSystems             []*xo.CodeSystem
 	CodeSystemConcepts      []*xo.CodeSystemConcept
 	ValueSets               []*xo.ValueSet
+	ValueSetConcepts        []*xo.ValueSet
 	URL                     string
 	PageCount               int
 }

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -33,7 +33,7 @@ func (r *Repository) GetCodeSystemByOID(ctx context.Context, oid string) (*xo.Co
 }
 
 func (r *Repository) SearchCodeSystems(ctx context.Context, searchTerm, lookupType string) (*[]xo.CodeSystem, error) {
-	if lookupType == "id" {
+	if lookupType == "uuid" {
 		return models.GetCodeSystemByLikeID(ctx, r.database, searchTerm)
 	} else if lookupType == "oid" {
 		return models.GetCodeSystemByLikeOID(ctx, r.database, searchTerm)

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -88,6 +88,16 @@ func (r *Repository) GetValueSetByVersionOID(ctx context.Context, vsv *xo.ValueS
 	return vsv.ValueSet(ctx, r.database)
 }
 
+func (r *Repository) SearchValueSets(ctx context.Context, searchTerm, lookupType string) (*[]xo.ValueSet, error) {
+	if lookupType == "uuid" {
+		return models.GetValueSetByLikeID(ctx, r.database, searchTerm)
+	} else if lookupType == "oid" {
+		return models.GetValueSetByLikeOID(ctx, r.database, searchTerm)
+	} else {
+		return models.GetValueSetByLikeString(ctx, r.database, searchTerm)
+	}
+}
+
 // =============================== //
 // ========= View methods ======== //
 // =============================== //

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -32,8 +32,14 @@ func (r *Repository) GetCodeSystemByOID(ctx context.Context, oid string) (*xo.Co
 	return xo.CodeSystemByOid(ctx, r.database, oid)
 }
 
-func (r *Repository) GetCodeSystemsByLikeOID(ctx context.Context, oid string) (*[]xo.CodeSystem, error) {
-	return models.GetCodeSystemByLikeOID(ctx, r.database, oid)
+func (r *Repository) SearchCodeSystems(ctx context.Context, searchTerm, lookupType string) (*[]xo.CodeSystem, error) {
+	if lookupType == "id" {
+		return models.GetCodeSystemByLikeID(ctx, r.database, searchTerm)
+	} else if lookupType == "oid" {
+		return models.GetCodeSystemByLikeOID(ctx, r.database, searchTerm)
+	} else {
+		return models.GetCodeSystemByLikeString(ctx, r.database, searchTerm)
+	}
 }
 
 // =============================== //

--- a/internal/database/models/valueset.go
+++ b/internal/database/models/valueset.go
@@ -24,3 +24,41 @@ func GetAllValueSets(ctx context.Context, db xo.DB) (*[]xo.ValueSet, error) {
 	}
 	return &valueSets, nil
 }
+
+func GetValueSetByLikeOID(ctx context.Context, db xo.DB, oid string) (*[]xo.ValueSet, error) {
+	wildcard := "%" + oid + "%"
+	const sqlstr = "SELECT * FROM public.value_set WHERE oid LIKE $1"
+
+	return queryValueSets(ctx, db, sqlstr, wildcard)
+}
+
+func GetValueSetByLikeID(ctx context.Context, db xo.DB, id string) (*[]xo.ValueSet, error) {
+	wildcard := "%" + id + "%"
+	const sqlstr = "SELECT * FROM public.value_set WHERE id LIKE $1"
+
+	return queryValueSets(ctx, db, sqlstr, wildcard)
+}
+
+func GetValueSetByLikeString(ctx context.Context, db xo.DB, input string) (*[]xo.ValueSet, error) {
+	wildcard := "%" + input + "%"
+	const sqlstr = "SELECT * FROM public.value_set WHERE lower(name) LIKE lower($1) OR lower(code) LIKE lower($1);"
+
+	return queryValueSets(ctx, db, sqlstr, wildcard)
+}
+
+func queryValueSets(ctx context.Context, db xo.DB, sqlstr, wildcard string) (*[]xo.ValueSet, error) {
+	valueSets := []xo.ValueSet{}
+	rows, err := db.QueryContext(ctx, sqlstr, wildcard)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		vs := xo.ValueSet{}
+		err := rows.Scan(&vs.Oid, &vs.ID, &vs.Name, &vs.Code, &vs.Status, &vs.Definitiontext, &vs.Scopenotetext, &vs.Assigningauthorityid, &vs.Legacyflag, &vs.Statusdate)
+		if err != nil {
+			return nil, err
+		}
+		valueSets = append(valueSets, vs)
+	}
+	return &valueSets, nil
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -55,9 +55,9 @@ func LogError(w http.ResponseWriter, r *http.Request, err error, errrorText stri
 	logger.Error(err.Error(), slog.String("method", r.Method), slog.String("uri", r.URL.RequestURI()))
 }
 
-func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm string, logger *slog.Logger) {
+func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm, searchType string, logger *slog.Logger) {
 	if errors.Is(err, sql.ErrNoRows) {
-		errorString := fmt.Sprintf("Error: Code System %s not found", searchTerm)
+		errorString := fmt.Sprintf("Error: no matching resources found for '%s'", searchTerm)
 		dbErr := &DatabaseError{
 			Err:    err,
 			Msg:    errorString,
@@ -73,7 +73,7 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 	} else {
 		LogError(w, r, err, http.StatusText(http.StatusInternalServerError), logger)
 
-		component := components.Error("search", err.Error())
+		component := components.Error("Search", err.Error())
 		component.Render(r.Context(), w)
 	}
 }

--- a/internal/ui/components/code_system_results-count.templ
+++ b/internal/ui/components/code_system_results-count.templ
@@ -1,0 +1,35 @@
+package components
+
+import "github.com/CDCgov/phinvads-go/internal/database/models"
+
+templ CodeSystemResultsCount(result *models.SearchResultRow) {
+    <div class="search-results__tabs">
+        <div 
+            if result.ValueSetsCount == "0" && result.CodeSystemsCount != "0" {
+                class="tab-item active"
+            } else {
+                class="tab-item"
+            }
+        >
+            Code Systems ({result.CodeSystemsCount})</div>
+        <div 
+            if result.ValueSetsCount == "0" && result.CodeSystemsCount == "0" && result.CodeSystemConceptsCount != "0"{
+                class="tab-item active"
+            } else {
+                class="tab-item"
+            }
+        >
+        Code System Concepts ({result.CodeSystemConceptsCount})</div>
+        <div 
+            if result.ValueSetsCount == "0" {
+               class="tab-item"
+            } else {
+                class="tab-item active"
+            }
+        >
+        Value Sets ({result.ValueSetsCount})</div>
+    </div>
+    
+}
+
+

--- a/internal/ui/components/search_results.templ
+++ b/internal/ui/components/search_results.templ
@@ -3,7 +3,7 @@ package components
 import "github.com/CDCgov/phinvads-go/internal/database/models"
 
 
-templ SearchResults(isDirect bool, currentPage, searchTerm string, searchResults *models.CodeSystemResultRow) {
+templ SearchResults(isDirect bool, currentPage, searchTerm string, searchResults *models.SearchResultRow) {
     @Base(currentPage) {
         <h1>
             Search
@@ -12,7 +12,11 @@ templ SearchResults(isDirect bool, currentPage, searchTerm string, searchResults
         <h2>
             Results: "{searchTerm}"
         </h2>
+        if searchResults.ValueSetsCount != "0" {
+            @ValueSetResult(searchTerm, searchResults)
+        } else {
             @CodeSystemResult(searchTerm, searchResults)
+        }
         <div><br></div>
     }
 }

--- a/internal/ui/components/value_set_result.templ
+++ b/internal/ui/components/value_set_result.templ
@@ -5,13 +5,15 @@ import (
     "github.com/CDCgov/phinvads-go/internal/database/models"
 )
 
-templ CodeSystemResult(searchTerm string, searchResults *models.SearchResultRow) {
+templ ValueSetResult(searchTerm string, searchResults *models.SearchResultRow) {
     <div>
-       @CodeSystemResultsCount(searchResults)
+       @ValueSetResultsCount(searchResults)
         <div class="search-results__table" role="table" aria-label="table">
             <div role="rowgroup">
                 <div class="cdc-header top-header">
-                                        <div class="col search-results page-count">Showing {strconv.Itoa(searchResults.PageCount)} of {searchResults.CodeSystemsCount} Code Systems</div>
+                    <div class="col search-results page-count">
+                        Showing {strconv.Itoa(searchResults.PageCount)} of {searchResults.ValueSetsCount} Value Sets
+                    </div>
                     <div 
                         if searchResults.PageCount >=5 {
                             class="pagination"
@@ -38,23 +40,25 @@ templ CodeSystemResult(searchTerm string, searchResults *models.SearchResultRow)
                                 Download Value Set
                             </button>         
                         } else {
-                            <button disabled aria-disabled="true">
-                                <img src="/assets/img/material-icons/file_download_off.svg">
+                            <button>
+                                <img src="/assets/img/material-icons/file_download.svg">
                                 Download Value Set
                             </button>
                         }
                     </div>
                 </div>
-               @CodeSystemTableHeader()
             </div>
-            <div role="rowgroup">
-                for idx, item := range searchResults.CodeSystems  {
+            <table>
+               @ValueSetTableHeader()
+                <div role="rowgroup">
+                for idx, item := range searchResults.ValueSets  {
                     if idx <= 4 {
                         // modulo check allows alternating background color
-                        @CodeSystemResultRow(idx % 2 != 0, item)
+                        @ValueSetResultRow(idx % 2 != 0, item)
                     }
                 }
             </div>
+            </table>
         </div>
     </div>
 }

--- a/internal/ui/components/value_set_result_count.templ
+++ b/internal/ui/components/value_set_result_count.templ
@@ -2,7 +2,7 @@ package components
 
 import "github.com/CDCgov/phinvads-go/internal/database/models"
 
-templ CodeSystemResultsCount(result *models.CodeSystemResultRow) {
+templ ValueSetResultsCount(result *models.SearchResultRow) {
     <div class="search-results__tabs">
         <div 
             if result.ValueSetsCount == "0" && result.CodeSystemsCount != "0" {
@@ -11,23 +11,31 @@ templ CodeSystemResultsCount(result *models.CodeSystemResultRow) {
                 class="tab-item"
             }
         >
-            Code Systems ({result.CodeSystemsCount})</div>
+            Views (Msg. Guides) (0)</div>
         <div 
-            if result.ValueSetsCount == "0" && result.CodeSystemsCount == "0" && result.CodeSystemConceptsCount != "0"{
+            if result.ValueSetsCount != "0" {
                 class="tab-item active"
             } else {
                 class="tab-item"
             }
         >
-        Code System Concepts ({result.CodeSystemConceptsCount})</div>
+        Value Sets ({result.ValueSetsCount})</div>
         <div 
             if result.ValueSetsCount == "0" {
-               class="tab-item"
+               class="tab-item active"
             } else {
-                class="tab-item active"
+                class="tab-item"
             }
         >
-        Value Sets ({result.ValueSetsCount})</div>
+        Value Set Concepts (0)</div>
+           <div 
+            if result.ValueSetsCount == "0" {
+               class="tab-item active"
+            } else {
+                class="tab-item"
+            }
+        >
+        Code System Concepts (0)</div>
     </div>
     
 }

--- a/internal/ui/components/value_set_result_row.templ
+++ b/internal/ui/components/value_set_result_row.templ
@@ -1,0 +1,47 @@
+package components
+
+import "github.com/CDCgov/phinvads-go/internal/database/models/xo"
+
+templ ValueSetResultRow(alternate bool, result *xo.ValueSet) {
+      <div 
+        if alternate == true {
+            class="row content-row" role="row"
+        } else {
+            class="row content-row alternate-bg" role="row"
+        }
+     >
+        <div class="col check">
+            <div role="cell">
+                <input 
+                    type="checkbox" 
+                    value={result.Oid}
+                >
+            </div>
+        </div>
+        <div class="col vs-code">
+            <div role="cell">
+                <p>{result.Code}</p>
+            </div>
+        </div>
+         <div class="col vs-name">
+            <div role="cell">
+                <p>{result.Name}</p>
+            </div>
+        </div>
+        <div class="col vs-version">
+            <div role="cell">
+                <p>1</p>
+            </div>
+        </div>
+        <div class="col vs-date">
+            <div role="cell">
+                <p>{result.Statusdate.Format("Jan. 2, 2006")}</p>
+            </div>
+        </div>
+        <div class="col vs-oid">
+            <div role="cell">
+                <p>{result.Oid}</p>
+            </div>
+        </div>
+    </div>
+}

--- a/internal/ui/components/value_set_table_header.templ
+++ b/internal/ui/components/value_set_table_header.templ
@@ -1,0 +1,36 @@
+package components
+
+templ ValueSetTableHeader() {
+     <div class="row cdc-header header-row" role="row">
+                    <div class="col check">
+                        <div role="cell">
+                            <input type="checkbox">
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">   
+                            <p>Value Set Code</p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">
+                            <p>Name</p>
+                        </div>
+                    </div>
+                    <div class="col vs-version">
+                        <div role="cell">
+                            <p>Version #</p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">
+                            <p>Effective Date</p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">
+                            <p>OID</p>
+                        </div>
+                    </div>
+                </div>
+}


### PR DESCRIPTION
## What this PR does:
- Updates search functionality to recognize the resource type selected in the dropdown menu (defaults to "All")
- When "Value Set" or "All" is selected, query the db for ValueSets* that match the input (string, id, or oid)
  - Update the table view to display ValueSet-specific column headers and data (per Figma mockup)
- Only when "Code System" is selected, query the db for CodeSystems that match the input
  - Display CodeSystem-specific column headers and data (as earlier code did)
- Adjust the "SearchResultRow" struct to contain result counts and additional data types 
- Dynamically render the appropriate template based on `SearchResultRow` data passed to `SearchResult.templ`
- Adds new templates for ValueSet results (result, result row, table header, result count)

## What this PR doesn't do:
- Does not support resource lookups for resources other than ValueSet and CodeSystem
  - `All` currently queries the ValueSet table only, not all resources
- For ValueSet searches, the column `Version` is hard-coded; will need a join on `value_set_version` to get accurate data returned
- Also for ValueSet searches, "effective date" is populated with data from the `statusdate` column; need data from `value_set_version` table to get `effective date`
- As with the initial CodeSystem result UI, pagination/download button/etc. are currently non-functional
- Templates could be organized better; I'd like to follow up in a separate PR to rework existing templates to be more re-usable between resource types