### PR TITLE
Use mux subroutes to organize routes by purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you'd prefer to not rely on Docker and instead run PostgreSQL locally, you wi
     ```bash
     pg_restore -d phinvads --no-owner --role=$(whoami) phinvads.dump
     ```
-    
+
 ### Linting
 
 Pull requests to the `main` branch are required to pass linting checks. To run these locally, [install `golangci-lint`](https://golangci-lint.run/welcome/install/#local-installation). Then you can `golangci-lint run` from the project directory.

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,14 @@ require (
 	github.com/a-h/templ v0.2.778
 	github.com/google/fhir/go v0.7.4
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/mux v1.8.1
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/justinas/alice v1.2.0
-	github.com/vearutop/statigz v1.4.2
 )
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9 // indirect
-	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
@@ -28,4 +27,5 @@ require (
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9 // indirect
+	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
+	github.com/vearutop/statigz v1.4.3 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -462,9 +464,12 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vearutop/statigz v1.4.3 h1:eDWkkbQuiG1h8Eu4feV3Rb1x6048LMNIudT77a7Husc=
+github.com/vearutop/statigz v1.4.3/go.mod h1:LYTolBLiz9oJISwiVKnOQoIwhO1LWX1A7OECawGS8XE=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/z-division/go-zookeeper v0.0.0-20190128072838-6d7457066b9b/go.mod h1:JNALoWa+nCXR8SmgLluHcBNVJgyejzpKPZk9pX2yXXE=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
-github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -70,8 +68,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bool64/dev v0.2.28 h1:6ayDfrB/jnNr2iQAZHI+uT3Qi6rErSbJYQs1y8rSrwM=
-github.com/bool64/dev v0.2.28/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/buger/jsonparser v0.0.0-20200322175846-f7e751efca13/go.mod h1:tgcrVJ81GPSF0mz+0nu1Xaz0fazGPrmmJfJtxjbHhUQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -230,6 +226,8 @@ github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -464,8 +462,6 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-github.com/vearutop/statigz v1.4.2 h1:R38TMyPBE4v1enzyo5bj1Gu0igws6fm8GDo5dVJs+k4=
-github.com/vearutop/statigz v1.4.2/go.mod h1:LYTolBLiz9oJISwiVKnOQoIwhO1LWX1A7OECawGS8XE=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -211,7 +211,7 @@ func (app *Application) getViewVersionByID(w http.ResponseWriter, r *http.Reques
 
 func (app *Application) getViewVersionsByViewID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	viewId := r.PathValue("viewId")
+	viewId := mux.Vars(r)["viewId"]
 
 	viewVersions, err := rp.GetViewVersionByViewId(r.Context(), viewId)
 	if err != nil {
@@ -332,7 +332,7 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	oid := r.PathValue("oid")
+	oid := mux.Vars(r)["oid"]
 
 	valueSetVersions, err := rp.GetValueSetVersionByValueSetOID(r.Context(), oid)
 	if err != nil {
@@ -426,7 +426,8 @@ func (app *Application) getValueSetConceptByID(w http.ResponseWriter, r *http.Re
 
 func (app *Application) getValueSetConceptsByVersionID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	id := r.PathValue("valueSetVersionId")
+
+	id := mux.Vars(r)["valueSetVersionId"]
 
 	valueSetConcepts, err := rp.GetValueSetConceptByValueSetVersionID(r.Context(), id)
 	if err != nil {
@@ -458,7 +459,7 @@ func (app *Application) getValueSetConceptsByVersionID(w http.ResponseWriter, r 
 
 func (app *Application) getValueSetConceptsByCodeSystemOID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	oid := r.PathValue("codeSystemOid")
+	oid := mux.Vars(r)["codeSystemOid"]
 
 	valueSetConcepts, err := rp.GetValueSetConceptsByCodeSystemOID(r.Context(), oid)
 	if err != nil {
@@ -591,7 +592,7 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 }
 
 func (app *Application) handleBannerToggle(w http.ResponseWriter, r *http.Request) {
-	action := r.PathValue("action")
+	action := mux.Vars(r)["action"]
 	component := components.UsaBanner(action)
 	component.Render(r.Context(), w)
 }

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CDCgov/phinvads-go/internal/ui/components"
 	"github.com/google/fhir/go/fhirversion"
 	"github.com/google/fhir/go/jsonformat"
+	"github.com/gorilla/mux"
 )
 
 func (app *Application) healthcheck(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +44,7 @@ func (app *Application) getAllCodeSystems(w http.ResponseWriter, r *http.Request
 func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 	id_type, err := determineIdType(id)
 	if err != nil {
 		customErrors.BadRequest(w, r, err, app.logger)
@@ -80,7 +81,7 @@ func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request
 func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 	id_type, err := determineIdType(id)
 	if err != nil {
 		customErrors.BadRequest(w, r, err, app.logger)
@@ -116,6 +117,10 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 	}
 
 	concepts, err := rp.GetCodeSystemConceptsByCodeSystemOID(r.Context(), app.db, codeSystem)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -154,7 +159,7 @@ func (app *Application) getAllViews(w http.ResponseWriter, r *http.Request) {
 
 func (app *Application) getViewByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 
 	view, err := rp.GetViewByID(r.Context(), id)
 	if err != nil {
@@ -180,7 +185,7 @@ func (app *Application) getViewByID(w http.ResponseWriter, r *http.Request) {
 
 func (app *Application) getViewVersionByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 
 	viewVersion, err := rp.GetViewVersionByID(r.Context(), id)
 	if err != nil {
@@ -245,7 +250,7 @@ func (app *Application) getAllCodeSystemConcepts(w http.ResponseWriter, r *http.
 func (app *Application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 
 	codeSystemConcept, err := rp.GetCodeSystemConceptByID(r.Context(), id)
 	if err != nil {
@@ -284,7 +289,7 @@ func (app *Application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 	id_type, err := determineIdType(id)
 	if err != nil {
 		customErrors.BadRequest(w, r, err, app.logger)
@@ -359,7 +364,7 @@ func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, 
 func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 
 	valueSetVersion, err := rp.GetValueSetVersionByID(r.Context(), id)
 	if err != nil {
@@ -390,7 +395,7 @@ func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Re
 
 func (app *Application) getValueSetConceptByID(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
-	id := r.PathValue("id")
+	id := mux.Vars(r)["id"]
 
 	valueSetConcept, err := rp.GetValueSetConceptByID(r.Context(), id)
 	if err != nil {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -51,7 +51,6 @@ func SetupApp(cfg *cfg.Config) *Application {
 
 	mainRouter := mux.NewRouter()
 
-	// subrouters
 	apiRouter := mainRouter.PathPrefix("/api").Subrouter()
 	app.setupApiRoutes(apiRouter)
 

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -1,14 +1,15 @@
 package app
 
 import (
-	"net/http"
-
 	"github.com/CDCgov/phinvads-go/internal/ui"
 	"github.com/gorilla/mux"
+	"github.com/vearutop/statigz"
+	"github.com/vearutop/statigz/brotli"
 )
 
 func (app *Application) setupClientRoutes(s *mux.Router) {
-	s.PathPrefix("/assets/").Handler(http.FileServer(http.FS(ui.Files)))
+	fs := statigz.FileServer(ui.Files, brotli.AddEncoding, statigz.EncodeOnInit)
+	s.PathPrefix("/assets/").Handler(fs)
 	s.HandleFunc("/search", app.directSearch).Methods("GET")
 	s.HandleFunc("/", app.home).Methods("GET")
 	s.HandleFunc("/toggle-banner/{action}", app.handleBannerToggle).Methods("GET")

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -3,11 +3,12 @@ package app
 import (
 	"net/http"
 
+	"github.com/CDCgov/phinvads-go/internal/ui"
 	"github.com/gorilla/mux"
 )
 
 func (app *Application) setupClientRoutes(s *mux.Router) {
-	s.PathPrefix("/assets/").Handler(http.StripPrefix("/assets/", http.FileServer(http.Dir("internal/ui/assets"))))
+	s.PathPrefix("/assets/").Handler(http.FileServer(http.FS(ui.Files)))
 	s.HandleFunc("/search", app.directSearch).Methods("GET")
 	s.HandleFunc("/", app.home).Methods("GET")
 	s.HandleFunc("/toggle-banner/{action}", app.handleBannerToggle).Methods("GET")
@@ -20,6 +21,7 @@ func (app *Application) setupFhirRoutes(s *mux.Router) {
 
 // The routes() method returns a servemux containing our application routes.
 func (app *Application) setupApiRoutes(s *mux.Router) {
+	s.StrictSlash(true) // match on /api or /api/
 	s.HandleFunc("/", app.healthcheck).Methods("GET")
 
 	s.HandleFunc("/code-systems", app.getAllCodeSystems).Methods("GET")

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -20,7 +20,6 @@ func (app *Application) setupFhirRoutes(s *mux.Router) {
 	s.HandleFunc("/CodeSystem/{id}", app.getFHIRCodeSystemByID).Methods("GET")
 }
 
-// The routes() method returns a servemux containing our application routes.
 func (app *Application) setupApiRoutes(s *mux.Router) {
 	s.StrictSlash(true) // match on /api or /api/
 	s.HandleFunc("/", app.healthcheck).Methods("GET")

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -6,51 +6,43 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (app *Application) clientRouter() *mux.Router {
-	r := mux.NewRouter()
-	r.PathPrefix("/assets/").Handler(http.StripPrefix("/assets/", http.FileServer(http.Dir("internal/ui/assets"))))
-	r.HandleFunc("/search", app.directSearch).Methods("GET")
-	r.HandleFunc("/", app.home).Methods("GET")
-	r.HandleFunc("/toggle-banner/{action}", app.handleBannerToggle).Methods("GET")
-	r.HandleFunc("/load-hot-topics", app.getAllHotTopics).Methods("GET")
-	return r
+func (app *Application) setupClientRoutes(s *mux.Router) {
+	s.PathPrefix("/assets/").Handler(http.StripPrefix("/assets/", http.FileServer(http.Dir("internal/ui/assets"))))
+	s.HandleFunc("/search", app.directSearch).Methods("GET")
+	s.HandleFunc("/", app.home).Methods("GET")
+	s.HandleFunc("/toggle-banner/{action}", app.handleBannerToggle).Methods("GET")
+	s.HandleFunc("/load-hot-topics", app.getAllHotTopics).Methods("GET")
 }
 
-func (app *Application) fhirRouter() *mux.Router {
-	r := mux.NewRouter()
-	r.HandleFunc("/r5/CodeSystem/{id}", app.getFHIRCodeSystemByID).Methods("GET")
-	return r
+func (app *Application) setupFhirRoutes(s *mux.Router) {
+	s.HandleFunc("/CodeSystem/{id}", app.getFHIRCodeSystemByID).Methods("GET")
 }
 
 // The routes() method returns a servemux containing our application routes.
-func (app *Application) apiRouter() *mux.Router {
-	r := mux.NewRouter()
+func (app *Application) setupApiRoutes(s *mux.Router) {
+	s.HandleFunc("/", app.healthcheck).Methods("GET")
 
-	r.HandleFunc("/api", app.healthcheck).Methods("GET")
+	s.HandleFunc("/code-systems", app.getAllCodeSystems).Methods("GET")
+	s.HandleFunc("/code-systems/{id}", app.getCodeSystemByID).Methods("GET")
 
-	r.HandleFunc("/api/code-systems", app.getAllCodeSystems).Methods("GET")
-	r.HandleFunc("/api/code-systems/{id}", app.getCodeSystemByID).Methods("GET")
+	s.HandleFunc("/code-system-concepts", app.getAllCodeSystemConcepts).Methods("GET")
+	s.HandleFunc("/code-system-concepts/{id}", app.getCodeSystemConceptByID).Methods("GET")
 
-	r.HandleFunc("/api/code-system-concepts", app.getAllCodeSystemConcepts).Methods("GET")
-	r.HandleFunc("/api/code-system-concepts/{id}", app.getCodeSystemConceptByID).Methods("GET")
+	s.HandleFunc("/value-sets", app.getAllValueSets).Methods("GET")
+	s.HandleFunc("/value-sets/{id}", app.getValueSetByID).Methods("GET")
+	s.HandleFunc("/value-sets/{oid}/versions", app.getValueSetVersionsByValueSetOID).Methods("GET")
 
-	r.HandleFunc("/api/value-sets", app.getAllValueSets).Methods("GET")
-	r.HandleFunc("/api/value-sets/{id}", app.getValueSetByID).Methods("GET")
-	r.HandleFunc("/api/value-sets/{oid}/versions", app.getValueSetVersionsByValueSetOID).Methods("GET")
+	s.HandleFunc("/value-set-versions/{id}", app.getValueSetVersionByID).Methods("GET")
 
-	r.HandleFunc("/api/value-set-versions/{id}", app.getValueSetVersionByID).Methods("GET")
+	s.HandleFunc("/views", app.getAllViews).Methods("GET")
+	s.HandleFunc("/views/{id}", app.getViewByID).Methods("GET")
 
-	r.HandleFunc("/api/views", app.getAllViews).Methods("GET")
-	r.HandleFunc("/api/views/{id}", app.getViewByID).Methods("GET")
+	s.HandleFunc("/view-versions/{id}", app.getViewVersionByID).Methods("GET")
+	s.HandleFunc("/view-versions-by-view/{viewId}", app.getViewVersionsByViewID).Methods("GET")
 
-	r.HandleFunc("/api/view-versions/{id}", app.getViewVersionByID).Methods("GET")
-	r.HandleFunc("/api/view-versions-by-view/{viewId}", app.getViewVersionsByViewID).Methods("GET")
+	s.HandleFunc("/value-set-concepts/{id}", app.getValueSetConceptByID).Methods("GET")
+	s.HandleFunc("/value-set-concepts/value-set-version/{valueSetVersionId}", app.getValueSetConceptsByVersionID).Methods("GET")
+	s.HandleFunc("/value-set-concepts/code-system/{codeSystemOid}", app.getValueSetConceptsByCodeSystemOID).Methods("GET")
 
-	r.HandleFunc("/api/value-set-concepts/{id}", app.getValueSetConceptByID).Methods("GET")
-	r.HandleFunc("/api/value-set-concepts/value-set-version/{valueSetVersionId}", app.getValueSetConceptsByVersionID).Methods("GET")
-	r.HandleFunc("/api/value-set-concepts/code-system/{codeSystemOid}", app.getValueSetConceptsByCodeSystemOID).Methods("GET")
-
-	r.HandleFunc("/api/search", app.formSearch).Methods("POST")
-
-	return r
+	s.HandleFunc("/search", app.formSearch).Methods("POST")
 }


### PR DESCRIPTION
## Summary

This PR swaps out the standard routing for [gorilla/mux](https://github.com/gorilla/mux). Mux allows us to make use of subrouters, which means we can very easily route requests to a specific prefix and all of the routes under that prefix will use it as a base for their paths automatically.

For example:
1. All FHIR related requests will go to the `/r5` subrouter
2. All routes within `setupFhirRoutes` will be grouped together
3. Additionally, all routes within `setupFhirRoutes` will use `/r5` as the base for their paths

## How to Test

Run `go mod tidy` to ensure mux is installed.

There should be no changes to the application. 

- All API routes (`/api` and `/r5`) should continue to work as they did previously
  - All example requests in `docs/examples.http` appear to work as expected in my testing
- The client app should still load in the browser and behave exactly as it did before
  - Styling should be unaffected
  - Static file compression should be working

## Remaining work / discussion

- Is there anything else that would make sense to change as part of this PR?