### PR TITLE
Add go checks to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,42 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.23.1'
+
+    - name: Install dependencies
+      run: go get .
+
+    - name: Check `go fmt`
+      run: test -z $(gofmt -l ./...)
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+
+    - name: Run `go vet`
+      run: go vet ./...
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,9 +21,6 @@ jobs:
       with:
         go-version: '1.23.1'
 
-    - name: Check `go fmt`
-      run: test -z $(gofmt -l ./...)
-
     - name: Install templ
       run: go install github.com/a-h/templ/cmd/templ@latest
 
@@ -34,9 +31,6 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         version: latest
-
-    - name: Run `go vet`
-      run: go vet ./...
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,11 +21,14 @@ jobs:
       with:
         go-version: '1.23.1'
 
-    # - name: Install dependencies
-    #   run: go get .
-
     - name: Check `go fmt`
       run: test -z $(gofmt -l ./...)
+
+    - name: Install templ
+      run: go install github.com/a-h/templ/cmd/templ@latest
+
+    - name: generate templ files
+      run: templ generate
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,8 @@ jobs:
       with:
         go-version: '1.23.1'
 
-    - name: Install dependencies
-      run: go get .
+    # - name: Install dependencies
+    #   run: go get .
 
     - name: Check `go fmt`
       run: test -z $(gofmt -l ./...)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  enable:
+    - decorder
+    - durationcheck
+    - errchkjson
+    - exhaustive
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - misspell
+    - prealloc
+    - predeclared
+    - reassign
+    - unconvert
+    - wastedassign
+    - whitespace

--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ If you'd prefer to not rely on Docker and instead run PostgreSQL locally, you wi
     ```bash
     pg_restore -d phinvads --no-owner --role=$(whoami) phinvads.dump
     ```
+    
+### Linting
+
+Pull requests to the `main` branch are required to pass linting checks. To run these locally, [install `golangci-lint`](https://golangci-lint.run/welcome/install/#local-installation). Then you can `golangci-lint run` from the project directory.

--- a/internal/app/fhir/r5/helpers.go
+++ b/internal/app/fhir/r5/helpers.go
@@ -54,6 +54,7 @@ func newUri(value string) *datatypespb.Uri {
 	return &datatypespb.Uri{Value: value}
 }
 
+//nolint:unused
 func newNullableUri(ns sql.NullString) *datatypespb.Uri {
 	if ns.Valid {
 		return newUri(ns.String)

--- a/internal/app/fhir/r5/helpers.go
+++ b/internal/app/fhir/r5/helpers.go
@@ -66,6 +66,7 @@ func newXhtml(value string) *datatypespb.Xhtml {
 	return &datatypespb.Xhtml{Value: value}
 }
 
+//nolint:gosec
 func newUnsignedInt(value int) *datatypespb.UnsignedInt {
 	return &datatypespb.UnsignedInt{Value: uint32(value)}
 }

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -125,6 +125,10 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 	}
 
 	concepts, err := rp.GetCodeSystemConceptsByCodeSystemOID(r.Context(), app.db, codeSystem)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -248,7 +252,10 @@ func (app *Application) getViewVersionsByViewID(w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(viewVersions)
+	err = json.NewEncoder(w).Encode(viewVersions)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getAllCodeSystemConcepts(w http.ResponseWriter, r *http.Request) {
@@ -260,7 +267,10 @@ func (app *Application) getAllCodeSystemConcepts(w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(codeSystemConcepts)
+	err = json.NewEncoder(w).Encode(codeSystemConcepts)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.Request) {
@@ -287,7 +297,10 @@ func (app *Application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(codeSystemConcept)
+	err = json.NewEncoder(w).Encode(codeSystemConcept)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getAllValueSets(w http.ResponseWriter, r *http.Request) {
@@ -299,7 +312,10 @@ func (app *Application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSets)
+	err = json.NewEncoder(w).Encode(valueSets)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) {
@@ -342,7 +358,10 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSet)
+	err = json.NewEncoder(w).Encode(valueSet)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, r *http.Request) {
@@ -374,7 +393,10 @@ func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, 
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSetVersions)
+	err = json.NewEncoder(w).Encode(valueSetVersions)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Request) {
@@ -406,7 +428,10 @@ func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSetVersion)
+	err = json.NewEncoder(w).Encode(valueSetVersion)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetConceptByID(w http.ResponseWriter, r *http.Request) {
@@ -437,7 +462,10 @@ func (app *Application) getValueSetConceptByID(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSetConcept)
+	err = json.NewEncoder(w).Encode(valueSetConcept)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetConceptsByVersionID(w http.ResponseWriter, r *http.Request) {
@@ -469,7 +497,10 @@ func (app *Application) getValueSetConceptsByVersionID(w http.ResponseWriter, r 
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSetConcepts)
+	err = json.NewEncoder(w).Encode(valueSetConcepts)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getValueSetConceptsByCodeSystemOID(w http.ResponseWriter, r *http.Request) {
@@ -500,7 +531,10 @@ func (app *Application) getValueSetConceptsByCodeSystemOID(w http.ResponseWriter
 	}
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(valueSetConcepts)
+	err = json.NewEncoder(w).Encode(valueSetConcepts)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getAllHotTopics(w http.ResponseWriter, r *http.Request) {
@@ -622,5 +656,8 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 func (app *Application) handleBannerToggle(w http.ResponseWriter, r *http.Request) {
 	action := r.PathValue("action")
 	component := components.UsaBanner(action)
-	component.Render(r.Context(), w)
+	err := component.Render(r.Context(), w)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -63,7 +63,7 @@ func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request
 	case Id:
 		codeSystem, err = rp.GetCodeSystemByID(r.Context(), id)
 	case Unknown:
-		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
+		panic("unreachable!")
 	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -106,7 +106,7 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 	case Id:
 		codeSystem, err = rp.GetCodeSystemByID(r.Context(), id)
 	case Unknown:
-		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
+		panic("unreachable!")
 	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -341,7 +341,7 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 	case Id:
 		valueSet, err = rp.GetValueSetByID(r.Context(), id)
 	case Unknown:
-		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
+		panic("unreachable!")
 	}
 
 	if err != nil {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -57,10 +57,13 @@ func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request
 	}
 
 	var codeSystem *xo.CodeSystem
-	if id_type == "oid" {
+	switch id_type {
+	case Oid:
 		codeSystem, err = rp.GetCodeSystemByOID(r.Context(), id)
-	} else {
+	case Id:
 		codeSystem, err = rp.GetCodeSystemByID(r.Context(), id)
+	case Unknown:
+		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
 	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -97,10 +100,13 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 	}
 
 	var codeSystem *xo.CodeSystem
-	if id_type == "oid" {
+	switch id_type {
+	case Oid:
 		codeSystem, err = rp.GetCodeSystemByOID(r.Context(), id)
-	} else {
+	case Id:
 		codeSystem, err = rp.GetCodeSystemByID(r.Context(), id)
+	case Unknown:
+		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
 	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -329,10 +335,13 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var valueSet *xo.ValueSet
-	if id_type == "oid" {
+	switch id_type {
+	case Oid:
 		valueSet, err = rp.GetValueSetByOID(r.Context(), id)
-	} else {
+	case Id:
 		valueSet, err = rp.GetValueSetByID(r.Context(), id)
+	case Unknown:
+		customErrors.ServerError(w, r, customErrors.ErrInvalidId, app.logger)
 	}
 
 	if err != nil {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -19,7 +19,10 @@ import (
 )
 
 func (app *Application) healthcheck(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("status: OK"))
+	_, err := w.Write([]byte("status: OK"))
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getAllCodeSystems(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +40,10 @@ func (app *Application) getAllCodeSystems(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(codeSystems)
+	err = json.NewEncoder(w).Encode(codeSystems)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +80,10 @@ func (app *Application) getCodeSystemByID(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(codeSystem)
+	err = json.NewEncoder(w).Encode(codeSystem)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +146,10 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	w.Write(fhirJson)
+	_, err = w.Write(fhirJson)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getAllViews(w http.ResponseWriter, r *http.Request) {
@@ -516,17 +528,27 @@ func (app *Application) getAllHotTopics(w http.ResponseWriter, r *http.Request) 
 		divId := fmt.Sprintf("m-a%s", strconv.Itoa(t.Seq))
 
 		component := components.HotTopic(t.HotTopicName, t.HotTopicDescription, divId, t.HotTopicID.String())
-		component.Render(r.Context(), w)
+		err = component.Render(r.Context(), w)
+		if err != nil {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
 	}
 }
 
 func (app *Application) home(w http.ResponseWriter, r *http.Request) {
 	component := components.Home()
-	component.Render(r.Context(), w)
+	err := component.Render(r.Context(), w)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) formSearch(w http.ResponseWriter, r *http.Request) {
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+		return
+	}
 	searchTerm := r.Form["search"][0]
 	searchType := r.Form["options"][0]
 	app.search(w, r, searchTerm, searchType)
@@ -582,7 +604,10 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request, searchTer
 	w.Header().Set("HX-Push-Url", fmt.Sprintf("/search?type=%s&input=%s", searchType, searchTerm))
 
 	component := components.SearchResults(true, "Search", searchTerm, result)
-	component.Render(r.Context(), w)
+	err = component.Render(r.Context(), w)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) handleBannerToggle(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -161,7 +161,10 @@ func (app *Application) getAllViews(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(views)
+	err = json.NewEncoder(w).Encode(views)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getViewByID(w http.ResponseWriter, r *http.Request) {
@@ -187,7 +190,10 @@ func (app *Application) getViewByID(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(view)
+	err = json.NewEncoder(w).Encode(view)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getViewVersionByID(w http.ResponseWriter, r *http.Request) {
@@ -213,7 +219,10 @@ func (app *Application) getViewVersionByID(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(viewVersion)
+	err = json.NewEncoder(w).Encode(viewVersion)
+	if err != nil {
+		customErrors.ServerError(w, r, err, app.logger)
+	}
 }
 
 func (app *Application) getViewVersionsByViewID(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -6,15 +6,24 @@ import (
 	"github.com/CDCgov/phinvads-go/internal/errors"
 )
 
-func determineIdType(input string) (output string, err error) {
+type IdType int
+
+const (
+	Unknown IdType = iota
+	Oid     IdType = iota
+	Id      IdType = iota
+)
+
+func determineIdType(input string) (output IdType, err error) {
 	validId, _ := regexp.MatchString("^[a-zA-Z0-9-]+$", input)
 	validOid, _ := regexp.MatchString("^[0-9.]+$", input)
 
-	if validId {
-		return "id", nil
-	} else if validOid {
-		return "oid", nil
-	} else {
-		return "", errors.ErrInvalidId
+	switch {
+	case validId:
+		return Id, nil
+	case validOid:
+		return Oid, nil
+	default:
+		return Unknown, errors.ErrInvalidId
 	}
 }

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
 	cfg "github.com/CDCgov/phinvads-go/internal/config"
 	"github.com/CDCgov/phinvads-go/internal/database"
 	rp "github.com/CDCgov/phinvads-go/internal/database/models/repository"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 type Application struct {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -34,6 +34,7 @@ func SetupApp(cfg *cfg.Config) *Application {
 
 	tlsConfig := &tls.Config{
 		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+		MinVersion:       tls.VersionTLS12,
 	}
 
 	rp := rp.NewRepository(db)
@@ -75,7 +76,7 @@ func (app *Application) Run() {
 
 	app.logger.Error(err.Error())
 
-	defer app.db.Close()
+	app.db.Close()
 
 	os.Exit(1)
 }

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -3,8 +3,8 @@ package app
 import (
 	"net/http"
 
-	"github.com/justinas/alice"
 	"github.com/CDCgov/phinvads-go/internal/ui"
+	"github.com/justinas/alice"
 	"github.com/vearutop/statigz"
 	"github.com/vearutop/statigz/brotli"
 )

--- a/internal/database/models/codesystemconcept.go
+++ b/internal/database/models/codesystemconcept.go
@@ -23,5 +23,4 @@ func GetAllCodeSystemConcepts(ctx context.Context, db xo.DB) (*[]xo.CodeSystemCo
 		codeSystemConcepts = append(codeSystemConcepts, csc)
 	}
 	return &codeSystemConcepts, nil
-
 }

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -183,5 +183,4 @@ func (r *Repository) GetValueSetVersionByVvsvVsvId(ctx context.Context, vvsv *xo
 
 func (r *Repository) GetAllHotTopics(ctx context.Context) (*[]xo.HotTopic, error) {
 	return models.GetAllHotTopics(ctx, r.database)
-
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,12 +69,18 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 		LogError(w, r, dbErr.Err, msg, logger)
 
 		component := components.Error("Search", dbErr.Msg)
-		component.Render(r.Context(), w)
+		_, err := component.Render(r.Context(), w)
+		if err != nil {
+			LogError(w, r, err, err, logger)
+		}
 	} else {
 		LogError(w, r, err, http.StatusText(http.StatusInternalServerError), logger)
 
 		component := components.Error("search", err.Error())
-		component.Render(r.Context(), w)
+		_, err := component.Render(r.Context(), w)
+		if err != nil {
+			LogError(w, r, err, err, logger)
+		}
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -71,7 +71,7 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 		component := components.Error("Search", dbErr.Msg)
 		err := component.Render(r.Context(), w)
 		if err != nil {
-			LogError(w, r, err, err, logger)
+			LogError(w, r, err, "Failed to render search error component", logger)
 		}
 	} else {
 		LogError(w, r, err, http.StatusText(http.StatusInternalServerError), logger)
@@ -79,7 +79,7 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 		component := components.Error("search", err.Error())
 		err := component.Render(r.Context(), w)
 		if err != nil {
-			LogError(w, r, err, err, logger)
+			LogError(w, r, err, "Failed to render search error component", logger)
 		}
 	}
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,7 +69,7 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 		LogError(w, r, dbErr.Err, msg, logger)
 
 		component := components.Error("Search", dbErr.Msg)
-		_, err := component.Render(r.Context(), w)
+		err := component.Render(r.Context(), w)
 		if err != nil {
 			LogError(w, r, err, err, logger)
 		}
@@ -77,7 +77,7 @@ func SearchError(w http.ResponseWriter, r *http.Request, err error, searchTerm s
 		LogError(w, r, err, http.StatusText(http.StatusInternalServerError), logger)
 
 		component := components.Error("search", err.Error())
-		_, err := component.Render(r.Context(), w)
+		err := component.Render(r.Context(), w)
 		if err != nil {
 			LogError(w, r, err, err, logger)
 		}


### PR DESCRIPTION
Add linting checks (both style and function) to our CI. Also fixing said linting errors.

* Primarily handling ignored error cases
* Some formatting
* Add min TLS version
* Remove defer on the closing of the db, since we're about to exit and defer's don't run on exit
* Turned `"oid"` and `"id` into an `IdType` enum and then used switch to test exhaustively

Things that need _serious scrutiny_ / are open questions:
* I erred on the side of just making everything a server error that was unhandled - this may or may not make sense
* If we're now using an enum for `IdType` and it has an `Unknown` case, do we need the error? or just lean on the unknown as bad (there's a lint check for exhaustive checking)
* Right now the action only runs on PRs to `main` - do we want to open that up? We can always only make it required on `main`