### PR TITLE
FHIR JSON resource matches spec MIME-type and encoding

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -136,8 +136,6 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-
 	fhirCodeSystem, err := r5.SerializeCodeSystemToFhir(codeSystem, conceptCount, concepts)
 	if err != nil {
 		customErrors.ServerError(w, r, err, app.logger)
@@ -156,6 +154,7 @@ func (app *Application) getFHIRCodeSystemByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/fhir+json; charset=UTF-8")
 	_, err = w.Write(fhirJson)
 	if err != nil {
 		customErrors.ServerError(w, r, err, app.logger)


### PR DESCRIPTION
## Summary

This PR updates `getFHIRCodeSystemByID` so that the `Content-Type` matches the MIME-type expected in FHIR R5. I've also explicitly included UTF-8 as the character encoding.

Here is what I'm referencing from the [spec](https://hl7.org/fhir/json.html):
```
- The character encoding is always UTF-8
- The MIME-type for this format is application/fhir+json.
```

Figured this could be a nice change early on in case this line begins getting copy/pasted 😅 

## Testing

This should have no real impact to our one existing FHIR API route aside from the changes listed above.

## Discussion

- This seems to be "best practice" rather than "strictly required". Any reasons we wouldn't want to follow best practice?